### PR TITLE
Bugfix (Xcode main thread warning)

### DIFF
--- a/Sources/TSMobileAnalytics/TSMobileAnalytics.swift
+++ b/Sources/TSMobileAnalytics/TSMobileAnalytics.swift
@@ -443,7 +443,10 @@ private extension TSMobileAnalytics {
             return
         }
 
-        UIApplication.shared.open(url)
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url)
+        }
+
     }
 
     static func deviceReference(applicationName: String) -> String? {


### PR DESCRIPTION
Fixed the xcode warning about Application.shared.open(url) in a background thread and not in the main thread